### PR TITLE
handle empty tiers for as.data.frame methods

### DIFF
--- a/R/as.data.frame.R
+++ b/R/as.data.frame.R
@@ -44,7 +44,7 @@ as.data.frame.IntervalTier <- function(x, row.names = NULL, optional = FALSE, ..
     .intervals
   )
   if (is.null(row.names)) {
-    row.names(.coerced) <- 1:nrow(.coerced)
+    row.names(.coerced) <- seq_len(nrow(.coerced))
   } else {
     row.names(.coerced) <- row.names
   }
@@ -75,7 +75,7 @@ as.data.frame.PointTier <- function(x, row.names = NULL, optional = FALSE, ..., 
     .points
   )
   if (is.null(row.names)) {
-    row.names(.coerced) <- 1:nrow(.coerced)
+    row.names(.coerced) <- seq_len(nrow(.coerced))
   } else {
     row.names(.coerced) <- row.names
   }
@@ -91,7 +91,7 @@ as.data.frame.TextGrid <- function(x, row.names = NULL, optional = FALSE, ..., s
     Map(f = as.data.frame, x = x, stringsAsFactors = list(stringsAsFactors))
   )
   if (is.null(row.names)) {
-    row.names(.coerced) <- 1:nrow(.coerced)
+    row.names(.coerced) <- seq_len(nrow(.coerced))
   } else {
     row.names(.coerced) <- row.names
   }


### PR DESCRIPTION
The row-naming part of the `as.data.frame()` methods inadvertently assumed that the tiers had at least one row. This assumption would raise an error on empty textgrids.