### PR TITLE
ability to read interval tiers with either 3 or 4 levels of tab

### DIFF
--- a/R/IntervalTier-utilities.R
+++ b/R/IntervalTier-utilities.R
@@ -1,20 +1,20 @@
 
 # Extract the start times of the intervals within a block of @praatText.
-.IntervalStartTimes <- function(praatText, pattern = '^( {12}|\t{3})xmin') {
+.IntervalStartTimes <- function(praatText, pattern = '^( {12}|\t{34})xmin') {
   .start_times <- .TierTimes(praatText, pattern)
   return(.start_times)
 }
 
 
 # Extract the end times of the intervals within a block of @praatText.
-.IntervalEndTimes <- function(praatText, pattern = '^( {12}|\t{3})xmax') {
+.IntervalEndTimes <- function(praatText, pattern = '^( {12}|\t{34})xmax') {
   .end_times <- .TierTimes(praatText, pattern)
   return(.end_times)
 }
 
 
 # Extract the text-mark values (interval labels) from a block of @praatText.
-.IntervalLabels <- function(praatText, pattern = '^( {12}|\t{3})(text|mark)') {
+.IntervalLabels <- function(praatText, pattern = '^( {12}|\t{34})(text|mark)') {
   .labels <- .TierLabels(praatText, pattern)
   return(.labels)
 }

--- a/R/IntervalTier-utilities.R
+++ b/R/IntervalTier-utilities.R
@@ -1,20 +1,20 @@
 
 # Extract the start times of the intervals within a block of @praatText.
-.IntervalStartTimes <- function(praatText, pattern = '^( {12}|\t{34})xmin') {
+.IntervalStartTimes <- function(praatText, pattern = '^( {12}|\t{3,4})xmin') {
   .start_times <- .TierTimes(praatText, pattern)
   return(.start_times)
 }
 
 
 # Extract the end times of the intervals within a block of @praatText.
-.IntervalEndTimes <- function(praatText, pattern = '^( {12}|\t{34})xmax') {
+.IntervalEndTimes <- function(praatText, pattern = '^( {12}|\t{3,4})xmax') {
   .end_times <- .TierTimes(praatText, pattern)
   return(.end_times)
 }
 
 
 # Extract the text-mark values (interval labels) from a block of @praatText.
-.IntervalLabels <- function(praatText, pattern = '^( {12}|\t{34})(text|mark)') {
+.IntervalLabels <- function(praatText, pattern = '^( {12}|\t{3,4})(text|mark)') {
   .labels <- .TierLabels(praatText, pattern)
   return(.labels)
 }

--- a/R/PointTier-utilities.R
+++ b/R/PointTier-utilities.R
@@ -1,13 +1,13 @@
 
 # Extract the times of the points within a block of @praatText.
-.PointTimes <- function(praatText, pattern = '^( {12}|\t{3})(time|number)') {
+.PointTimes <- function(praatText, pattern = '^( {12}|\t{3,4})(time|number)') {
   .times <- .TierTimes(praatText, pattern)
   return(.times)
 }
 
 
 # Extract the labels of the points within a block of @praatText.
-.PointLabels <- function(praatText, pattern = '^( {12}|\t{3})(text|mark)') {
+.PointLabels <- function(praatText, pattern = '^( {12}|\t{3,4})(text|mark)') {
   .labels <- .TierLabels(praatText, pattern)
   return(.labels)
 }


### PR DESCRIPTION
Some versions of Praat seem to save interval tier information with 3 levels of tabs (newer??), and others with 4 levels (older??).  This can now read both.